### PR TITLE
Update the minimum supported version of Winston to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/jaakkos/winston-logstash.git"
   },
   "peerDependencies": {
-    "winston": ">=0.7.3"
+    "winston": ">=0.8.1"
   },
   "devDependencies": {
     "winston": ">=0.7.3",


### PR DESCRIPTION
Winston 0.8.1 is the first version to support labels in messages, which the tests require. Previous versions fail